### PR TITLE
Fix duplicate file names when sharing media from apps like WhatsApp

### DIFF
--- a/zikzak_share_handler_android/android/src/main/kotlin/wtf/zikzak/zikzak_share_handler/ShareHandlerPlugin.kt
+++ b/zikzak_share_handler_android/android/src/main/kotlin/wtf/zikzak/zikzak_share_handler/ShareHandlerPlugin.kt
@@ -1,9 +1,13 @@
-package wtf.zikzak.zikzak_share_handler
+package com.shoutsocial.share_handler
 
+import android.content.ContentResolver
 import android.content.Context
 import android.content.Intent
 import android.graphics.BitmapFactory
 import android.net.Uri
+import android.provider.OpenableColumns
+import android.util.Log
+import android.webkit.MimeTypeMap
 
 import androidx.annotation.NonNull
 import androidx.core.app.Person
@@ -15,12 +19,18 @@ import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.embedding.engine.plugins.activity.ActivityAware
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
 import io.flutter.plugin.common.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
 import java.net.URLConnection
 
-private const val kEventsChannel = "wtf.zikzak.zikzak_share_handler/sharedMediaStream"
+private const val kEventsChannel = "com.shoutsocial.share_handler/sharedMediaStream"
 
 /** ShareHandlerPlugin */
-class ShareHandlerPlugin: FlutterPlugin, Messages.ShareHandlerApi, EventChannel.StreamHandler, ActivityAware, PluginRegistry.NewIntentListener {
+class ShareHandlerPlugin : FlutterPlugin, Messages.ShareHandlerApi, EventChannel.StreamHandler, ActivityAware,
+  PluginRegistry.NewIntentListener {
   private var initialMedia: Messages.SharedMedia? = null
   private var eventChannel: EventChannel? = null
   private var eventSink: EventChannel.EventSink? = null
@@ -42,40 +52,6 @@ class ShareHandlerPlugin: FlutterPlugin, Messages.ShareHandlerApi, EventChannel.
     Messages.ShareHandlerApi.setup(binding.binaryMessenger, null)
   }
 
-//  override fun getInitialSharedMedia(result: Result<SharedMedia>?) {
-//    result?.let { _result -> {
-//      initialMedia?.let { _media -> _result.success(_media) }
-//    } }
-//  }
-
-//  override fun recordSentMessage(media: SharedMedia) {
-//    val packageName = applicationContext.packageName
-//    val shortcutTarget = "$packageName.dynamic_share_target"
-//    val shortcutBuilder = ShortcutInfoCompat.Builder(applicationContext, media.conversationIdentifier ?: "").setShortLabel(media.speakableGroupName ?: "Unknown")
-//      .setIsConversation()
-//      .setCategories(setOf(shortcutTarget))
-//      .setIntent(Intent(Intent.ACTION_DEFAULT))
-//      .setLongLived(true)
-//
-//    val personBuilder = Person.Builder()
-//      .setKey(media.conversationIdentifier)
-//      .setName(media.speakableGroupName)
-//
-//    media.imageFilePath?.let {
-//      val bitmap = BitmapFactory.decodeFile(it)
-//      val icon = IconCompat.createWithAdaptiveBitmap(bitmap)
-//      shortcutBuilder.setIcon(icon)
-//      personBuilder.setIcon(icon)
-//    }
-//
-//    val person = personBuilder.build()
-//    shortcutBuilder.setPerson(person)
-//
-//    val shortcut = shortcutBuilder.build()
-//
-//    ShortcutManagerCompat.addDynamicShortcuts(applicationContext, listOf(shortcut))
-//  }
-
   override fun getInitialSharedMedia(result: Messages.Result<Messages.SharedMedia>?) {
     result?.success(initialMedia)
   }
@@ -90,7 +66,8 @@ class ShareHandlerPlugin: FlutterPlugin, Messages.ShareHandlerApi, EventChannel.
 //      putExtra("conversationIdentifier", media.conversationIdentifier)
 //    }
     val shortcutTarget = "$packageName.dynamic_share_target"
-    val shortcutBuilder = ShortcutInfoCompat.Builder(applicationContext, media.conversationIdentifier ?: "").setShortLabel(media.speakableGroupName ?: "Unknown")
+    val shortcutBuilder = ShortcutInfoCompat.Builder(applicationContext, media.conversationIdentifier ?: "")
+      .setShortLabel(media.speakableGroupName ?: "Unknown")
       .setIsConversation()
       .setCategories(setOf(shortcutTarget))
       .setIntent(intent)
@@ -152,41 +129,40 @@ class ShareHandlerPlugin: FlutterPlugin, Messages.ShareHandlerApi, EventChannel.
   }
 
   private fun handleIntent(intent: Intent, initial: Boolean) {
-    val attachments: List<Messages.SharedAttachment>?
-    val text: String?
-    when {
-      (intent.type?.startsWith("text") != true)
-              && (intent.action == Intent.ACTION_SEND
-              || intent.action == Intent.ACTION_SEND_MULTIPLE) -> { // Sharing images or videos
+    val attachments: List<Messages.SharedAttachment>? = try {
+      attachmentsFromIntent(intent)
+    } catch (e: Exception) {
+      Log.e("TAG", "Error parsing attachments", e)
+      null
+    }
 
-        attachments = attachmentsFromIntent(intent)
-        text = null
-      }
-      (intent.type == null || intent.type?.startsWith("text") == true)
-              && intent.action == Intent.ACTION_SEND -> { // Sharing text
-        text = intent.getStringExtra(Intent.EXTRA_TEXT)
-        attachments = if (text == null) {
-          attachmentsFromIntent(intent)
-        } else {
-          null
+    val text: String? = when (intent.action) {
+      Intent.ACTION_SEND, Intent.ACTION_SEND_MULTIPLE -> intent.getStringExtra(Intent.EXTRA_TEXT)
+      Intent.ACTION_VIEW -> intent.dataString
+      else -> null
+    }
+
+    val conversationIdentifier = intent.getStringExtra("android.intent.extra.shortcut.ID")
+      ?: intent.getStringExtra("conversationIdentifier")
+
+    if (attachments != null || text != null || conversationIdentifier != null) {
+      val mediaBuilder = Messages.SharedMedia.Builder()
+      attachments?.let { mediaBuilder.setAttachments(it) }
+      text?.let { mediaBuilder.setContent(it) }
+      conversationIdentifier?.let { mediaBuilder.setConversationIdentifier(it) }
+      val media = mediaBuilder.build()
+
+      if (initial) {
+        synchronized(this) {
+          initialMedia = media
         }
       }
-      intent.action == Intent.ACTION_VIEW -> { // Opening URL
-        attachments = null
-        text = intent.dataString
+
+      if (eventSink != null) {
+        eventSink?.success(media.toMap())
+      } else {
+        Log.w("TAG", "EventSink is not available")
       }
-      else -> {
-        attachments = null
-        text = null
-      }
-    }
-//    val conversationIdentifier = intent.getStringExtra(Intent.EXTRA_SHORTCUT_ID)
-    val conversationIdentifier = intent.getStringExtra("android.intent.extra.shortcut.ID") ?: intent.getStringExtra("conversationIdentifier")
-    if (attachments != null || text != null || conversationIdentifier != null) {
-//      val media = SharedMedia(attachments = attachments, content = text)
-      val media = Messages.SharedMedia.Builder().setAttachments(attachments).setContent(text).setConversationIdentifier(conversationIdentifier).build()
-      if (initial) initialMedia = media
-      eventSink?.success(media.toMap())
     }
   }
 
@@ -197,6 +173,7 @@ class ShareHandlerPlugin: FlutterPlugin, Messages.ShareHandlerApi, EventChannel.
         val uri = intent.getParcelableExtra<Uri>(Intent.EXTRA_STREAM) ?: return null
         return listOf(attachmentForUri(uri)).mapNotNull { it }
       }
+
       Intent.ACTION_SEND_MULTIPLE -> {
         val uris = intent.getParcelableArrayListExtra<Uri>(Intent.EXTRA_STREAM)
         val value = uris?.mapNotNull { uri ->
@@ -204,23 +181,114 @@ class ShareHandlerPlugin: FlutterPlugin, Messages.ShareHandlerApi, EventChannel.
         }?.toList()
         return value
       }
+
       else -> null
     }
   }
 
   private fun attachmentForUri(uri: Uri): Messages.SharedAttachment? {
-    val path = FileDirectory.getAbsolutePath(applicationContext, uri)
-    return if (path != null) {
-      val type = getAttachmentType(path)
-//      SharedAttachment(path = path, type = type)
-      Messages.SharedAttachment.Builder().setPath(path).setType(type).build()
+    val contentResolver = applicationContext.contentResolver
+
+    // Obtain the MIME type of the URI
+    val mimeType = contentResolver.getType(uri)
+
+    // Get the absolute path from the URI
+    val path = FileDirectory.getAbsolutePath(applicationContext, uri) ?: return null
+
+    val file = File(path)
+
+    // Check if the file name has an extension
+    if (file.extension.isNotEmpty()) {
+      // File has an extension; use it directly
+      val type = getAttachmentType(mimeType)
+      return Messages.SharedAttachment.Builder()
+        .setPath(file.absolutePath)
+        .setType(type)
+        .build()
     } else {
-      null
+      // File does not have an extension; copy it to cache with the correct extension
+
+      // Obtain the file name from the URI, including extension
+      val fileName = getFileNameFromUri(contentResolver, uri, mimeType) ?: return null
+
+      // Create a new file in the cache directory with the correct file name
+      val newFile = File(applicationContext.cacheDir, fileName)
+
+      // Copy the contents from the URI to the new file
+      val success = copyFile(contentResolver, uri, newFile)
+      if (!success) {
+        return null
+      }
+
+      // Determine the attachment type using the MIME type
+      val type = getAttachmentType(mimeType)
+
+      // Return the attachment with the path to the copied file
+      return Messages.SharedAttachment.Builder()
+        .setPath(newFile.absolutePath)
+        .setType(type)
+        .build()
     }
   }
 
-  private fun getAttachmentType(path: String?): Messages.SharedAttachmentType {
-    val mimeType = URLConnection.guessContentTypeFromName(path)
+  // Function to get the file name from the URI
+  private fun getFileNameFromUri(contentResolver: ContentResolver, uri: Uri, mimeType: String?): String? {
+    var fileName: String? = null
+    val cursor = contentResolver.query(uri, null, null, null, null)
+    cursor?.use { c ->
+      if (c.moveToFirst()) {
+        val nameIndex = c.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+        if (nameIndex != -1) {
+          fileName = c.getString(nameIndex)
+        }
+      }
+    }
+
+    // Si no se pudo obtener el nombre del archivo, generar uno
+    if (fileName == null) {
+      fileName = "file_${System.currentTimeMillis()}"
+    }
+
+    // Si el nombre del archivo no tiene extensión, añadir una según el mimeType
+    val extension = fileName.substringAfterLast('.', "")
+    if (extension.isEmpty() || fileName.endsWith('.')) {
+      mimeType?.let {
+        val newExtension = MimeTypeMap.getSingleton().getExtensionFromMimeType(it)
+        if (!newExtension.isNullOrEmpty()) {
+          // Verificar si el nombre termina con un punto
+          fileName = if (fileName.endsWith('.')) {
+            fileName + newExtension
+          } else {
+            "$fileName.$newExtension"
+          }
+        }
+      }
+    }
+
+    return fileName
+  }
+
+  // Function to copy the file content from the URI to the destination file
+  private fun copyFile(contentResolver: ContentResolver, uri: Uri, destinationFile: File): Boolean {
+    return try {
+      contentResolver.openInputStream(uri)?.use { inputStream ->
+        FileOutputStream(destinationFile).use { outputStream ->
+          val buffer = ByteArray(8 * 1024) // 8KB buffer
+          var bytesRead: Int
+          while (inputStream.read(buffer).also { bytesRead = it } != -1) {
+            outputStream.write(buffer, 0, bytesRead)
+          }
+        }
+      }
+      true
+    } catch (e: Exception) {
+      e.printStackTrace()
+      false
+    }
+  }
+
+  // Function to determine the attachment type using the MIME type
+  private fun getAttachmentType(mimeType: String?): Messages.SharedAttachmentType {
     return when {
       mimeType?.startsWith("image") == true -> Messages.SharedAttachmentType.image
       mimeType?.startsWith("video") == true -> Messages.SharedAttachmentType.video

--- a/zikzak_share_handler_ios/ios/Models/Classes/ShareHandlerIosViewController.swift
+++ b/zikzak_share_handler_ios/ios/Models/Classes/ShareHandlerIosViewController.swift
@@ -26,10 +26,11 @@ open class ShareHandlerIosViewController: UIViewController {
     let fileURLType = UTType.fileURL.identifier
     let dataContentType = UTType.data.identifier
     var sharedAttachments: [SharedAttachment] = []
+    private var fileNameCounter: [String: Int] = [:]
     lazy var userDefaults: UserDefaults = {
         return UserDefaults(suiteName: ShareHandlerIosViewController.appGroupId)!
     }()
-    
+
     public func loadIds() {
             // loading Share extension App Id
             let shareExtensionAppBundleIdentifier = Bundle.main.bundleIdentifier!;
@@ -44,22 +45,22 @@ open class ShareHandlerIosViewController: UIViewController {
             // loading custom AppGroupId from Build Settings or use group.<hostAppBundleIdentifier>
         ShareHandlerIosViewController.appGroupId = (Bundle.main.object(forInfoDictionaryKey: "AppGroupId") as? String) ?? "group.\(ShareHandlerIosViewController.hostAppBundleIdentifier)";
         }
-    
+
     public override func viewDidLoad() {
         super.viewDidLoad();
-        
+
         // load group and app id from build info
                 loadIds();
         Task {
             await handleInputItems()
         }
     }
-    
+
     public override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         extensionContext!.completeRequest(returningItems: [], completionHandler: nil)
     }
-    
+
     func handleInputItems() async {
         if let content = extensionContext!.inputItems[0] as? NSExtensionItem {
             if let contents = content.attachments {
@@ -83,23 +84,23 @@ open class ShareHandlerIosViewController: UIViewController {
                     } catch {
                         self.dismissWithError()
                     }
-                    
+
                 }
             }
             redirectToHostApp()
         }
     }
-    
+
     public func getNewFileUrl(fileName: String) -> URL {
         let newFileUrl = FileManager.default
             .containerURL(forSecurityApplicationGroupIdentifier: ShareHandlerIosViewController.appGroupId)!
             .appendingPathComponent(fileName)
         return newFileUrl
     }
-    
+
     public func handleText (content: NSExtensionItem, attachment: NSItemProvider, index: Int) async throws {
         let data = try await attachment.loadItem(forTypeIdentifier: textContentType, options: nil)
-        
+
         if let item = data as? String {
             sharedText.append(item)
         } else {
@@ -118,22 +119,22 @@ open class ShareHandlerIosViewController: UIViewController {
                 dismissWithError()
             }
         }
-    } 
-    
+    }
+
     public func handleUrl (content: NSExtensionItem, attachment: NSItemProvider, index: Int) async throws {
         let data = try await attachment.loadItem(forTypeIdentifier: urlContentType, options: nil)
-        
+
             if let item = data as? URL {
                 sharedText.append(item.absoluteString)
             } else {
                 dismissWithError()
             }
-        
+
     }
-    
+
     public func handleImages (content: NSExtensionItem, attachment: NSItemProvider, index: Int) async throws {
         let data = try await attachment.loadItem(forTypeIdentifier: imageContentType, options: nil)
-            
+
         var fileName: String?
         var imageData: Data?
         var sourceUrl: URL?
@@ -147,7 +148,7 @@ open class ShareHandlerIosViewController: UIViewController {
             fileName = UUID().uuidString + ".png"
             imageData = image.pngData()
         }
-        
+
         if let _fileName = fileName {
             let newFileUrl = getNewFileUrl(fileName: _fileName)
             do {
@@ -157,35 +158,35 @@ open class ShareHandlerIosViewController: UIViewController {
             } catch {
                 print("Error removing item")
             }
-            
-            
+
+
             var copied: Bool = false
             if let _data = imageData {
                 copied = FileManager.default.createFile(atPath: newFileUrl.path, contents: _data)
             } else if let _sourceUrl = sourceUrl {
                 copied = copyFile(at: _sourceUrl, to: newFileUrl)
             }
-            
+
             if (copied) {
                 sharedAttachments.append(SharedAttachment.init(path:  newFileUrl.absoluteString, type: .image))
             } else {
                 dismissWithError()
                 return
             }
-            
+
         } else {
             dismissWithError()
             return
         }
-        
+
     }
-    
+
     public func handleVideos (content: NSExtensionItem, attachment: NSItemProvider, index: Int) async throws {
         let data = try await attachment.loadItem(forTypeIdentifier: movieContentType, options: nil)
-         
-            
+
+
         if let url = data as? URL {
-            
+
             // Always copy
             let fileName = getFileName(from: url, type: .video)
             let newFileUrl = getNewFileUrl(fileName: fileName)
@@ -196,14 +197,14 @@ open class ShareHandlerIosViewController: UIViewController {
         } else {
             dismissWithError()
         }
-        
+
     }
-    
+
     public func handleFiles (content: NSExtensionItem, attachment: NSItemProvider, index: Int) async throws {
         let data = try await attachment.loadItem(forTypeIdentifier: fileURLType, options: nil)
-         
+
         if let url = data as? URL {
-            
+
             // Always copy
             let fileName = getFileName(from :url, type: .file)
             let newFileUrl = getNewFileUrl(fileName: fileName)
@@ -214,14 +215,14 @@ open class ShareHandlerIosViewController: UIViewController {
         } else {
             dismissWithError()
         }
-        
+
     }
-    
+
     public func handleData (content: NSExtensionItem, attachment: NSItemProvider, index: Int) async throws {
         let data = try await attachment.loadItem(forTypeIdentifier: dataContentType, options: nil)
-         
+
         if let url = data as? URL {
-            
+
             // Always copy
             let fileName = getFileName(from :url, type: .file)
             let newFileUrl = getNewFileUrl(fileName: fileName)
@@ -232,43 +233,43 @@ open class ShareHandlerIosViewController: UIViewController {
         } else {
             dismissWithError()
         }
-        
+
     }
-    
+
     public func dismissWithError() {
         print("[ERROR] Error loading data!")
         let alert = UIAlertController(title: "Error", message: "Error loading data", preferredStyle: .alert)
-        
+
         let action = UIAlertAction(title: "Error", style: .cancel) { _ in
             self.dismiss(animated: true, completion: nil)
         }
-        
+
         alert.addAction(action)
         present(alert, animated: true, completion: nil)
         extensionContext!.completeRequest(returningItems: [], completionHandler: nil)
     }
-    
+
     public func redirectToHostApp() {
         // ids may not loaded yet so we need loadIds here too
         loadIds();
         let url = URL(string: "ShareMedia-\(ShareHandlerIosViewController.hostAppBundleIdentifier)://\(ShareHandlerIosViewController.hostAppBundleIdentifier)?key=\(sharedKey)")
         var responder = self as UIResponder?
         let selectorOpenURL = sel_registerName("openURL:")
-        
+
         let intent = self.extensionContext?.intent as? INSendMessageIntent
-        
+
         let conversationIdentifier = intent?.conversationIdentifier
         let sender = intent?.sender
         let serviceName = intent?.serviceName
         let speakableGroupName = intent?.speakableGroupName
-        
+
         let sharedMedia = SharedMedia.init(attachments: sharedAttachments, conversationIdentifier: conversationIdentifier, content: sharedText.joined(separator: "\n"), speakableGroupName: speakableGroupName?.spokenPhrase, serviceName: serviceName, senderIdentifier: sender?.contactIdentifier ?? sender?.customIdentifier, imageFilePath: nil)
-        
+
         let json = sharedMedia.toJson()
-        
+
         userDefaults.set(json, forKey: sharedKey)
         userDefaults.synchronize()
-        
+
         while (responder != nil) {
             if let application = responder as? UIApplication {
                 application.open(url!, options: [:], completionHandler: nil)
@@ -277,20 +278,20 @@ open class ShareHandlerIosViewController: UIViewController {
             responder = responder!.next
         }
     }
-    
+
     enum RedirectType {
         case media
         case text
         case file
     }
-    
+
     func getExtension(from url: URL, type: SharedAttachmentType) -> String {
         let parts = url.lastPathComponent.components(separatedBy: ".")
         var ex: String? = nil
         if (parts.count > 1) {
             ex = parts.last
         }
-        
+
         if (ex == nil) {
             switch type {
             case .image:
@@ -305,17 +306,21 @@ open class ShareHandlerIosViewController: UIViewController {
         }
         return ex ?? "Unknown"
     }
-    
+
     func getFileName(from url: URL, type: SharedAttachmentType) -> String {
         var name = url.lastPathComponent
-        
         if (name.isEmpty) {
             name = UUID().uuidString + "." + getExtension(from: url, type: type)
         }
-        
+        if let count = fileNameCounter[name] {
+            fileNameCounter[name] = count + 1
+            name = "\((name as NSString).deletingPathExtension)_\(count + 1).\((name as NSString).pathExtension)"
+        } else {
+            fileNameCounter[name] = 1
+        }
         return name
     }
-    
+
     func copyFile(at srcURL: URL, to dstURL: URL) -> Bool {
         do {
             if FileManager.default.fileExists(atPath: dstURL.path) {


### PR DESCRIPTION
This commit addresses an issue where sharing media from certain apps, such as WhatsApp, sometimes results in duplicate file names for different photos or videos. The fix ensures that each shared file receives a unique name, even when the source app provides the same filename for multiple items.

Changes:
- Updated the getFileName function to append a counter to filenames
- Implemented a filename tracking mechanism to detect and handle duplicates

This fix improves the reliability of media sharing and prevents potential file overwrites when handling multiple media items with identical names.